### PR TITLE
Fix build with -Werror=incompatible-pointer-types

### DIFF
--- a/src/_crypt_r.c
+++ b/src/_crypt_r.c
@@ -83,7 +83,7 @@ crypt_r_crypt(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 
 
 static PyMethodDef crypt_r_methods[] = {
-    {"crypt", crypt_r_crypt, METH_FASTCALL, crypt_r_crypt__doc__},
+    {"crypt", (PyCFunction)crypt_r_crypt, METH_FASTCALL, crypt_r_crypt__doc__},
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/tox.ini
+++ b/tox.ini
@@ -6,3 +6,5 @@ env_list = py{311,312,313}
 [testenv]
 commands =
     python tests/test_crypt_r.py {posargs}
+setenv =
+    CFLAGS=-Werror=incompatible-pointer-types


### PR DESCRIPTION
And hence fix build with GCC 14 on Fedora 40+.